### PR TITLE
Use urllib.parse.unquote for unquoting url. And attempt to fix some dependency issue.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,56 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+.env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+/data/*

--- a/downloader.py
+++ b/downloader.py
@@ -1,5 +1,5 @@
 #!python3
-from urllib.parse import urlparse
+from urllib.parse import urlparse, unquote
 
 import appdirs
 import argparse
@@ -53,8 +53,8 @@ class downloadUI(ttk.Frame):
 
     def chooseFile(self):
         filePath = filedialog.askopenfilename(
-                filetypes=(("Json files", "*.json"),), 
-                initialdir=os.path.expanduser("~"), 
+                filetypes=(("Json files", "*.json"),),
+                initialdir=os.path.expanduser("~"),
                 parent=self)
         self.manifestPath.set(filePath)
 
@@ -147,7 +147,7 @@ def doDownload(manifest):
             source = fileResponse
             fileResponse = sess.get(source, stream=True)
         filePath = Path(fileResponse.url)
-        fileName = filePath.name.replace("%20", " ")
+        fileName = unquote(filePath.name)
         print("[%d/%d] %s" % (i, iLen, fileName))
         programGui.setOutput("[%d/%d] %s" % (i, iLen, fileName))
         with open(str(minecraftPath / "mods" / fileName), "wb") as mod:

--- a/setup.py
+++ b/setup.py
@@ -13,5 +13,10 @@ setup(
     name="cursePackDownloader",
     version="0.2",
     description="Download extra mods from Curse-hosted Minecraft modpacks",
-    executables=[Executable("downloader.py", targetName=targetName)]
+    executables=[Executable("downloader.py", targetName=targetName)],
+    install_requires=[
+        'appdirs',
+        'requests',
+        'tk'
+    ]
 )

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,8 @@ if sys.platform == "win32":
     targetName = "cursePackDownloader.exe"
 
 setup(
-    name = "cursePackDownloader",
-    version = "0.2",
-    description = "Download extra mods from Curse-hosted Minecraft modpacks",
-    executables = [Executable("downloader.py", targetName=targetName)])
+    name="cursePackDownloader",
+    version="0.2",
+    description="Download extra mods from Curse-hosted Minecraft modpacks",
+    executables=[Executable("downloader.py", targetName=targetName)]
+)


### PR DESCRIPTION
In this pull requests, I have done the following.

1. Use urllib.parse.unquote to unquote file name in variable fileName. Originally, only `%20` can be converted. After this change, all quoted url can be unquoted. Although it is not common to see any special character in Minecraft mods file name, this is the right way to unquote paths.
2. Add .gitignore. I found out git is tracking my env file when I was testing. I think you should take a look at [this](http://www.dabapps.com/blog/introduction-to-pip-and-virtualenv-python/)
3. Added dependency to setup.py. There are four depending packages but they were not listed. This does NOT add cx_freeze to dependency as adding it requires changing setup.py a lot.