### PR TITLE
Fix #17: No such file or directory: minecraft/mods/

### DIFF
--- a/downloader.py
+++ b/downloader.py
@@ -116,9 +116,10 @@ def doDownload(manifest):
 
     if not minecraftPath.exists():
         minecraftPath.mkdir()
-        modsPath = minecraftPath / "mods"
-        if not modsPath.exists():
-            modsPath.mkdir()
+        
+    modsPath = minecraftPath / "mods"
+    if not modsPath.exists():
+        modsPath.mkdir()
 
     sess = requests.session()
 


### PR DESCRIPTION
Fixes an error if `minecraft/` exists but `minecraft/mods/` does not.

Fixes #17