### PR TITLE
Fixed the infinite redirect bug caused by improper auth cookie handling.

### DIFF
--- a/downloader.py
+++ b/downloader.py
@@ -148,8 +148,17 @@ def doDownload(manifest):
                 continue
 
         # File is not cached and needs to be downloaded
-        projectResponse = sess.get("https://minecraft.curseforge.com/projects/%s" % (dependency['projectID']), stream=True)
-        projectResponse.url = projectResponse.url.replace('?cookieTest=1', '')
+        projectResponse = sess.get("https://minecraft.curseforge.com/projects/%s" % (dependency['projectID']), stream=True, allow_redirects=False)
+        
+        auth_cookie = None
+        for redirect in sess.resolve_redirects(projectResponse, projectResponse.request):
+             sess.cookies.update({'Auth.Token': auth_cookie})
+             if redirect.headers.get('Set-Cookie') is not None:
+                  cookie_list = redirect.headers.get('Set-Cookie').split(";")[0].split("=")
+                  if cookie_list[0] == 'Auth.Token':
+                        auth_cookie = cookie_list[1]
+             projectResponse.url = redirect.url
+
         fileResponse = sess.get("%s/files/%s/download" % (projectResponse.url, dependency['fileID']), stream=True)
         while fileResponse.is_redirect:
             source = fileResponse


### PR DESCRIPTION
I don't know how many people this bug causes problems for, but in some cases python requests wouldn't set the Auth.Token cookie for the appropriate domain.  (Curse would set a cookie for curseforge.com but was set from auth.curse.com)  Interesting enough, this bug also impacts firefox and links (for me) because of the same reason.  